### PR TITLE
Updated Major Airports and Overland FSS

### DIFF
--- a/docs/policy/global-ratings-policy.mdx
+++ b/docs/policy/global-ratings-policy.mdx
@@ -409,7 +409,7 @@ None designated
 
 *Special Centers*
 1. BICC_FSS - Iceland Radio (Oceanic)
-2. EGGX_FSS - Shanwick Radio (Oceanic)
+2. EGGX_CTR - Shanwick Radio (Oceanic)
 3. ENOB_FSS - Bodo Radio (Oceanic)
 4. EURM_CTR - Eurocontrol Maastricht Radar (above FL245)
 5. LON_CTR - London Centre
@@ -471,7 +471,7 @@ None designated
 37. TNCM
 
 *Special Centers*
-1. CZQX_FSS - Gander Radio (Oceanic)
+1. CZQX_CTR - Gander Radio (Oceanic)
 2. ZAK_FSS - San Francisco Radio (Oceanic)
 3. MIA_O_CTR - Miami Radio (Oceanic)
 4. NY_JBC_FSS - New York Radio (Oceanic)
@@ -479,7 +479,7 @@ None designated
 6. ZHU_79_FSS - Houston Radio (Oceanic)
 7. CZEG_FSS - Edmonton Radio (Domestic)
 8. MMZT_FSS - Mazatlan Oceanic FIR
-9. NAT_FSS - Shanwick & Gander Bandbox (Oceanic)
+9. NAT_FSS - Gander & Shanwick Bandbox (Oceanic)
 
 *Approved Overland FSS*
 1. CARI_FSS - Caribbean Control

--- a/docs/policy/global-ratings-policy.mdx
+++ b/docs/policy/global-ratings-policy.mdx
@@ -359,9 +359,12 @@ In addition to the competencies outlined in sections A-E above, in accordance wi
 1. LLLL_CTR
 
 *Approved Overland FSS*
-1. AFR_C_FSS - Central Africa Centre
-2. AFR_N_FSS - North Africa Centre
-3. GULF_FSS - Persian Gulf Centre
+1. GULF_FSS - Gulf Control (above FL245)
+2. AFRN_FSS - North Africa Control (above FL245)
+3. AFRE_FSS - East Africa Control (above FL245)
+4. AFRS_FSS - South Africa Control (above FL245)
+5. AFRW_FSS - West Africa Control (above FL245)
+6. AFRC_FSS - Central Africa Control (above FL245)
 
 **ASIA REGION**
 
@@ -416,16 +419,15 @@ None designated
 
 *Approved Overland FSS*
 1. EURE_FSS - Eurocontrol East Radar (above FL245)
-2. EURI_FSS - Eurocontrol Islands Radar (above FL245)
-3. EURN_FSS - Eurocontrol North Radar (above FL245)
-4. EURS_FSS - Eurocontrol South Radar (above FL245)
-5. EURW_FSS - Eurocontrol West Radar (above FL245)
-6. RU-CEN_FSS - Central Asia Control
-7. RU-ERC_FSS - Eastern Russia Control
-8. RU-ESC_FSS - Eastern Siberia Control
-9. RU-NWC_FSS - North Western Russia Control
-10. RU-WRC_FSS - Western Russia Control
-11. RU-WSC_FSS - Western Siberia Control
+2. EURN_FSS - Eurocontrol North Radar (above FL245)
+3. EURS_FSS - Eurocontrol South Radar (above FL245)
+4. EURW_FSS - Eurocontrol West Radar (above FL245)
+5. RU-CEN_FSS - Central Asia Control
+6. RU-ERC_FSS - Eastern Russia Control
+7. RU-ESC_FSS - Eastern Siberia Control
+8. RU-NWC_FSS - North Western Russia Control
+9. RU-WRC_FSS - Western Russia Control
+10. RU-WSC_FSS - Western Siberia Control
 
 **NORTH AMERICA REGION**
 
@@ -481,6 +483,8 @@ None designated
 
 *Approved Overland FSS*
 1. CARI_FSS - Caribbean Control
+2. CARE_FSS - Caribbean Control East
+3. CARW_FSS - Caribbean Control West
 
 **OCEANIA REGION**
 
@@ -513,7 +517,7 @@ None Designated
 None Designated
 
 *Approved Overland FSS*
-1. SAM-N_FSS - South America Control North
-2. SAM-E_FSS - South America Control East
-3. SAM-S_FSS - South America Control South
-4. SAM-W_FSS - South America Control West
+1. SAM-N_FSS - South America Control North (above FL245)
+2. SAM-E_FSS - South America Control East (above FL245)
+3. SAM-S_FSS - South America Control South (above FL245)
+4. SAM-W_FSS - South America Control West (above FL245)

--- a/docs/policy/global-ratings-policy.mdx
+++ b/docs/policy/global-ratings-policy.mdx
@@ -373,12 +373,12 @@ None designated
 
 *Special Centers*
 1. RJTG_FSS - Tokyo Radio (Oceanic)
+2. VCL_CTR - Mekong Radar
 
 *Approved Overland FSS*
 1. ASEA_FSS - South East Asia Centre
 2. ASIA_W_FSS - Asia West Centre
-3. PRC FSS - Beijing Control
-
+3. PRC_FSS - Beijing Control
 
 **EUROPE REGION**
 
@@ -471,7 +471,7 @@ None designated
 37. TNCM
 
 *Special Centers*
-1. CZQX_CTR - Gander Radio (Oceanic)
+1. CZQO_CTR - Gander Radio (Oceanic)
 2. ZAK_FSS - San Francisco Radio (Oceanic)
 3. MIA_O_CTR - Miami Radio (Oceanic)
 4. NY_JBC_FSS - New York Radio (Oceanic)

--- a/docs/policy/global-ratings-policy.mdx
+++ b/docs/policy/global-ratings-policy.mdx
@@ -387,23 +387,22 @@ None designated
 5. EDDK
 6. EDDL
 7. EDDM
-8. EDDT
-9. EGLL
-10. EHAM
-11. EKCH
-12. ENGM
-13. EPWA
-14. ESSA
-15. LEMD
-16. LFPG
-17. LGAV
-18. LHBP
-19. LOWI
-20. LOWW
-21. LPPT
-22. LSZH
-23. LTBA
-24. UUDD
+8. EGLL
+9. EHAM
+10. EKCH
+11. ENGM
+12. EPWA
+13. ESSA
+14. LEMD
+15. LFPG
+16. LGAV
+17. LHBP
+18. LOWI
+19. LOWW
+20. LPPT
+21. LSZH
+22. LTBA
+23. UUDD
 
 *Special Centers*
 1. BICC_FSS - Iceland Radio (Oceanic)
@@ -413,6 +412,7 @@ None designated
 5. LON_CTR - London Centre
 6. LPPO_FSS - Santa Maria Radio (Oceanic)
 7. UKR_CTR - Ukraine Centre
+8. NAT_FSS - Shanwick & Gander Bandbox (Oceanic)
 
 *Approved Overland FSS*
 1. EURE_FSS - Eurocontrol East Radar (above FL245)
@@ -477,7 +477,10 @@ None designated
 6. ZHU_79_FSS - Houston Radio (Oceanic)
 7. CZEG_FSS - Edmonton Radio (Domestic)
 8. MMZT_FSS - Mazatlan Oceanic FIR
+9. NAT_FSS - Shanwick & Gander Bandbox (Oceanic)
 
+*Approved Overland FSS*
+1. CARI_FSS - Caribbean Control
 
 **OCEANIA REGION**
 
@@ -508,3 +511,9 @@ None Designated
 
 *Special Centers*
 None Designated
+
+*Approved Overland FSS*
+1. SAM-N_FSS - South America Control North
+2. SAM-E_FSS - South America Control East
+3. SAM-S_FSS - South America Control South
+4. SAM-W_FSS - South America Control West


### PR DESCRIPTION
- Added NAT_FSS (Shanwick & Gander Bandbox)
- Updated Shanwick and Gander from FSS to CTR 
- Removed EDDT (airport closed in 2020 and was replaced by EDDB)
- Removed Eurocontrol Islands (closed in 2020/2021)
- Added Caribbean Control (approved in 2021)
- Added South America Control (approved in 2021)
- Updated Gulf Control Callsign
- Updated Africa Control Positions
- Added Mekong Radar
- Corrected several typos